### PR TITLE
Calculate size of push item on fly

### DIFF
--- a/pubtools/_content_gateway/push_staged_cgw.py
+++ b/pubtools/_content_gateway/push_staged_cgw.py
@@ -2,6 +2,7 @@ import os
 import json
 import pluggy
 import logging
+
 from pushsource import CGWPushItem
 from .push_base import PushBase
 from .utils import yaml_parser, validate_data, sort_items
@@ -81,7 +82,10 @@ class PushStagedCGW(PushBase):
                             self.process_version(pitem)
                         if pitem["type"] == "file":
                             for push_item in self.push_items:
-                                if push_item.src == pitem["metadata"]["pushItemPath"]:
+                                if (
+                                    push_item.src.replace(push_item.origin, "").lstrip("/")
+                                    == pitem["metadata"]["pushItemPath"]
+                                ):
                                     break
                             else:
                                 raise ValueError(
@@ -91,7 +95,7 @@ class PushStagedCGW(PushBase):
                             pitem["metadata"]["downloadURL"] = pulp_push_item.cdn_path
                             pitem["metadata"]["md5"] = item.md5sum
                             pitem["metadata"]["sha256"] = pulp_push_item.sha256sum
-                            pitem["metadata"]["size"] = pulp_push_item.size
+                            pitem["metadata"]["size"] = os.stat(push_item.src).st_size
                             self.process_file(pitem)
 
                     self.make_visible()

--- a/tests/test_push_staged_cgw.py
+++ b/tests/test_push_staged_cgw.py
@@ -44,8 +44,8 @@ def get_pulp_push_item():
 
 @mock.patch("pubtools._content_gateway.push_base.CGWClient", return_value=TestClient())
 def test_cgw_operations_success(mocked_cgw_client, target_setting):
-    cgw_item = CGWPushItem(name="cgw_push.yaml", src=yaml_file_path, origin=test_dir)
-    file_item = FilePushItem(name="file_push.yaml", src=yaml_file_path, origin=test_dir)
+    cgw_item = CGWPushItem(name="cgw_push.yaml", src=os.path.join(test_dir, yaml_file_path), origin=test_dir)
+    file_item = FilePushItem(name="file_push.yaml", src=os.path.join(test_dir, yaml_file_path), origin=test_dir)
 
     pulp_push_item = get_pulp_push_item()
     push_cgw = PushStagedCGW("fake_target_name", target_setting)


### PR DESCRIPTION
Because pulp doens't actually store size of push item, it needs to be calculated here in pubtools-content-gateway