### PR TITLE
Drop Python2 support

### DIFF
--- a/.github/workflows/tox-tests.yml
+++ b/.github/workflows/tox-tests.yml
@@ -3,22 +3,6 @@ name: Tox tests
 on: [push, pull_request]
 
 jobs:
-  py27:
-    runs-on: ubuntu-20.04
-    steps:
-      - uses: actions/checkout@v2
-      - name: Update existing dependencies
-        run: sudo apt-get update -y
-      - name: Install system dependencies
-        run: sudo apt-get install -y libkrb5-dev
-      - name: Setup Python
-        uses: actions/setup-python@v2
-        with:
-          python-version: 2.7
-      - name: Install Tox
-        run: pip install tox
-      - name: Run Tox
-        run: tox -e py27 -vv
   py37:
     runs-on: ubuntu-latest
     steps:

--- a/docs/README.rst
+++ b/docs/README.rst
@@ -17,7 +17,6 @@ The internal service which utilizes this library is called `rcm-pub`.
 Requirements
 ============
 
-- Python 2.6+
 - Python 3.5+
 
 --------------------------------

--- a/legacy.constraints
+++ b/legacy.constraints
@@ -1,8 +1,0 @@
-# Oldest supported versions of major libraries can be added to this
-# file. They'll be tested with Python 2.7.
-
-# constraints from pushsource
-attrs==17.4.0
-# constraints from pushsource, pushcollector
-jsonschema==2.3.0
-pytest-cov==2.8.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,6 @@
 attrs
 cffi
 pycparser
-six
 urllib3
 requests
 setuptools

--- a/setup.py
+++ b/setup.py
@@ -72,7 +72,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: GNU Lesser General Public License v3 (LGPLv3)",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 2.7",
     "Programming Language :: Python :: 3",
     "Programming Language :: Python :: 3.6",
     "Programming Language :: Python :: 3.9",
@@ -103,7 +102,7 @@ setup(
         ]
     },
     include_package_data=True,
-    python_requires=">=2.6",
+    python_requires=">=3.6",
     project_urls={
         "Changelog": "https://release-engineering.github.io/pubtools-content-gateway/CHANGELOG.html",
         "Documentation": "https://release-engineering.github.io/pubtools-content-gateway/",

--- a/tests/fake_cgw_client.py
+++ b/tests/fake_cgw_client.py
@@ -1,5 +1,4 @@
 from pubtools._content_gateway.cgw_client import CGWClientError
-import six
 import inspect
 
 
@@ -32,8 +31,7 @@ class TestClientMeta(type):
         return type.__new__(cls, clsname, bases, new_attrs)
 
 
-@six.add_metaclass(TestClientMeta)
-class TestClient(object):
+class TestClient(object, metaclass=TestClientMeta):
     def __init__(self, *args, **kwargs):
         self.products = {}
         self.product_versions = {}

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,py37,py39,black,flake8,docs
+envlist = py37,py39,black,flake8,docs
 skip_missing_interpreters = true
 
 [testenv]
@@ -11,11 +11,6 @@ commands=
         --cov-report xml --cov-report html {posargs}
 
 whitelist_externals = sh
-
-[testenv:py27]
-deps =
-    -rtest-requirements.txt
-    -clegacy.constraints
 
 [pytest]
 testpaths = tests


### PR DESCRIPTION
After Supercharge Pub 3 was delivered, Python 2 support is no longer required in it's dependencies as well. Dropping Python 2 will make the repos easier to maintain and will speed up Tox and Github Actions since some steps can be removed.