### PR TITLE
Support RAW content push [CLOUDDST-18677]

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -659,6 +659,10 @@ def test_staging_dir():
     return os.path.join(os.path.dirname(__file__), "test_data/test_staging_dir")
 
 
+def test_staging_dir_raw():
+    return os.path.join(os.path.dirname(__file__), "test_data/test_staging_dir_raw")
+
+
 @pytest.fixture()
 def fixture_source_stage(request):
     yield Source.register_backend("stage", lambda: request.param)

--- a/tests/test_data/test_staging_dir_raw/origin/CGW/cgw.yaml
+++ b/tests/test_data/test_staging_dir_raw/origin/CGW/cgw.yaml
@@ -1,0 +1,40 @@
+- type: product
+  action: create
+  metadata:
+    name: "Test Product"
+    productCode: "TestProduct"
+    homepage: "https://test.com/"
+    downloadpage: "https://test.com/"
+    thankYouPage: "https://test.com/"
+    eloquaCode: "NOT_SET"
+    featuredArtifactType: "Server"
+    thankYouTimeout: 5
+
+- type: product_version
+  action: create
+  metadata:
+    productName: "Test Product"
+    productCode: "TestProduct"
+    versionName: "TestProductVersion"
+    ga: true
+    masterProductVersion: null
+    termsAndConditions: "Anonymous Download"
+    trackingDisabled: true
+    hidden: true
+    invisible: true
+    releaseDate: "01-01-1900"
+
+- type: file
+  action: create
+  metadata:
+    type: "FILE"
+    productName: "Test Product"
+    productCode: "TestProduct"
+    productVersionName: "TestProductVersion"
+    description: "Test description"
+    label: "Release Info"
+    order: 0
+    hidden: false
+    pushItemPath: "origin/RAW/dummy.txt"
+    shortURL: "/test-1/example-v4/testing/"
+    differentProductThankYouPage:

--- a/tests/test_data/test_staging_dir_raw/origin/RAW/dummy.txt
+++ b/tests/test_data/test_staging_dir_raw/origin/RAW/dummy.txt
@@ -1,0 +1,1 @@
+dummy txt file


### PR DESCRIPTION
RAW files are pushed to CDN directly and not go into pulp repository. Get checksums from staging directory and downloadURL from checksum.