### PR TITLE
adjust schema for Pub pushes without pushItemPath [CLOUDDST-22463 ]

### DIFF
--- a/pubtools/_content_gateway/push_staged_cgw.py
+++ b/pubtools/_content_gateway/push_staged_cgw.py
@@ -113,54 +113,37 @@ class PushStagedCGW(PushBase):
                                     if isinstance(push_item, DirectoryPushItem):
                                         found = "directory_item"
                                     elif (
-                                        push_item.src.replace(push_item.origin, "").lstrip(
-                                            "/"
-                                        )
+                                        push_item.src.replace(push_item.origin, "").lstrip("/")
                                         == pitem["metadata"]["pushItemPath"]
                                     ):
                                         found = "file_item"
                                     if found:
                                         break
-                                    else:
-                                        raise ValueError(
-                                            "Unable to find push item with path:%s"
-                                            % pitem["metadata"]["pushItemPath"]
-                                        )
+                                else:
+                                    raise ValueError(
+                                        "Unable to find push item with path:%s" % pitem["metadata"]["pushItemPath"]
+                                    )
                                 if found == "file_item":
-                                    pulp_push_unit = self.pulp_push_units[
-                                        self.push_item_str(push_item)
-                                    ]
-                                    pulp_push_item = self.processed_push_items[
-                                        self.push_item_str(push_item)
-                                    ]
-                                    pitem["metadata"][
-                                        "downloadURL"
-                                    ] = pulp_push_unit.cdn_path
+                                    pulp_push_unit = self.pulp_push_units[self.push_item_str(push_item)]
+                                    pulp_push_item = self.processed_push_items[self.push_item_str(push_item)]
+                                    pitem["metadata"]["downloadURL"] = pulp_push_unit.cdn_path
                                     pitem["metadata"]["md5"] = pulp_push_item.md5sum
                                     pitem["metadata"]["sha256"] = pulp_push_unit.sha256sum
-                                    pitem["metadata"]["size"] = os.stat(
-                                        push_item.src
-                                    ).st_size
+                                    pitem["metadata"]["size"] = os.stat(push_item.src).st_size
                                 else:
-                                    filename = pitem["metadata"]["pushItemPath"].split("/")[
-                                        -1
-                                    ]
+                                    filename = pitem["metadata"]["pushItemPath"].split("/")[-1]
                                     file_path = os.path.join(push_item.src, filename)
                                     with open(file_path, "rb") as f:
                                         bytes = f.read()
-                                        pitem["metadata"]["md5"] = hashlib.md5(
-                                            bytes
-                                        ).hexdigest()
-                                        pitem["metadata"]["sha256"] = hashlib.sha256(
-                                            bytes
-                                        ).hexdigest()
+                                        pitem["metadata"]["md5"] = hashlib.md5(bytes).hexdigest()
+                                        pitem["metadata"]["sha256"] = hashlib.sha256(bytes).hexdigest()
                                     pitem["metadata"]["size"] = os.path.getsize(file_path)
-                                    pitem["metadata"][
-                                        "downloadURL"
-                                    ] = "/content/origin/files/sha256/{0}/{1}/{2}".format(
-                                        pitem["metadata"]["sha256"][:2],
-                                        pitem["metadata"]["sha256"],
-                                        filename,
+                                    pitem["metadata"]["downloadURL"] = (
+                                        "/content/origin/files/sha256/{0}/{1}/{2}".format(
+                                            pitem["metadata"]["sha256"][:2],
+                                            pitem["metadata"]["sha256"],
+                                            filename,
+                                        )
                                     )
                             # carry out CGW operations
                             self.process_file(pitem)
@@ -168,9 +151,7 @@ class PushStagedCGW(PushBase):
                     self.make_visible()
                     LOG.info("\n All CGW operations are successfully completed...!")
                 except Exception as error:
-                    LOG.exception(
-                        "Exception occurred during the CGW operation %s" % error
-                    )
+                    LOG.exception("Exception occurred during the CGW operation %s" % error)
                     LOG.info("Rolling back the partial operation")
                     self.rollback_cgw_operation()
 

--- a/pubtools/_content_gateway/push_staged_cgw.py
+++ b/pubtools/_content_gateway/push_staged_cgw.py
@@ -106,7 +106,7 @@ class PushStagedCGW(PushBase):
                         if pitem.get("type") == "product_version":
                             self.process_version(pitem)
                         if pitem["type"] == "file":
-                            if "pushItemPath" in pitem:
+                            if "pushItemPath" in pitem["metadata"]:
                                 # push to CDN and set required pitem attributes for CGW entry
                                 found = None
                                 for push_item in self.push_items:

--- a/pubtools/_content_gateway/push_staged_cgw.py
+++ b/pubtools/_content_gateway/push_staged_cgw.py
@@ -106,45 +106,71 @@ class PushStagedCGW(PushBase):
                         if pitem.get("type") == "product_version":
                             self.process_version(pitem)
                         if pitem["type"] == "file":
-                            found = None
-                            for push_item in self.push_items:
-                                if isinstance(push_item, DirectoryPushItem):
-                                    found = "directory_item"
-                                elif (
-                                    push_item.src.replace(push_item.origin, "").lstrip("/")
-                                    == pitem["metadata"]["pushItemPath"]
-                                ):
-                                    found = "file_item"
-                                if found:
-                                    break
-                            else:
-                                raise ValueError(
-                                    "Unable to find push item with path:%s" % pitem["metadata"]["pushItemPath"]
-                                )
-                            if found == "file_item":
-                                pulp_push_unit = self.pulp_push_units[self.push_item_str(push_item)]
-                                pulp_push_item = self.processed_push_items[self.push_item_str(push_item)]
-                                pitem["metadata"]["downloadURL"] = pulp_push_unit.cdn_path
-                                pitem["metadata"]["md5"] = pulp_push_item.md5sum
-                                pitem["metadata"]["sha256"] = pulp_push_unit.sha256sum
-                                pitem["metadata"]["size"] = os.stat(push_item.src).st_size
-                            else:
-                                filename = pitem["metadata"]["pushItemPath"].split("/")[-1]
-                                file_path = os.path.join(push_item.src, filename)
-                                with open(file_path, "rb") as f:
-                                    bytes = f.read()
-                                    pitem["metadata"]["md5"] = hashlib.md5(bytes).hexdigest()
-                                    pitem["metadata"]["sha256"] = hashlib.sha256(bytes).hexdigest()
-                                pitem["metadata"]["size"] = os.path.getsize(file_path)
-                                pitem["metadata"]["downloadURL"] = "/content/origin/files/sha256/{0}/{1}/{2}".format(
-                                    pitem["metadata"]["sha256"][:2], pitem["metadata"]["sha256"], filename
-                                )
+                            if "pushItemPath" in pitem:
+                                # push to CDN and set required pitem attributes for CGW entry
+                                found = None
+                                for push_item in self.push_items:
+                                    if isinstance(push_item, DirectoryPushItem):
+                                        found = "directory_item"
+                                    elif (
+                                        push_item.src.replace(push_item.origin, "").lstrip(
+                                            "/"
+                                        )
+                                        == pitem["metadata"]["pushItemPath"]
+                                    ):
+                                        found = "file_item"
+                                    if found:
+                                        break
+                                    else:
+                                        raise ValueError(
+                                            "Unable to find push item with path:%s"
+                                            % pitem["metadata"]["pushItemPath"]
+                                        )
+                                if found == "file_item":
+                                    pulp_push_unit = self.pulp_push_units[
+                                        self.push_item_str(push_item)
+                                    ]
+                                    pulp_push_item = self.processed_push_items[
+                                        self.push_item_str(push_item)
+                                    ]
+                                    pitem["metadata"][
+                                        "downloadURL"
+                                    ] = pulp_push_unit.cdn_path
+                                    pitem["metadata"]["md5"] = pulp_push_item.md5sum
+                                    pitem["metadata"]["sha256"] = pulp_push_unit.sha256sum
+                                    pitem["metadata"]["size"] = os.stat(
+                                        push_item.src
+                                    ).st_size
+                                else:
+                                    filename = pitem["metadata"]["pushItemPath"].split("/")[
+                                        -1
+                                    ]
+                                    file_path = os.path.join(push_item.src, filename)
+                                    with open(file_path, "rb") as f:
+                                        bytes = f.read()
+                                        pitem["metadata"]["md5"] = hashlib.md5(
+                                            bytes
+                                        ).hexdigest()
+                                        pitem["metadata"]["sha256"] = hashlib.sha256(
+                                            bytes
+                                        ).hexdigest()
+                                    pitem["metadata"]["size"] = os.path.getsize(file_path)
+                                    pitem["metadata"][
+                                        "downloadURL"
+                                    ] = "/content/origin/files/sha256/{0}/{1}/{2}".format(
+                                        pitem["metadata"]["sha256"][:2],
+                                        pitem["metadata"]["sha256"],
+                                        filename,
+                                    )
+                            # carry out CGW operations
                             self.process_file(pitem)
 
                     self.make_visible()
                     LOG.info("\n All CGW operations are successfully completed...!")
                 except Exception as error:
-                    LOG.exception("Exception occurred during the CGW operation %s" % error)
+                    LOG.exception(
+                        "Exception occurred during the CGW operation %s" % error
+                    )
                     LOG.info("Rolling back the partial operation")
                     self.rollback_cgw_operation()
 

--- a/pubtools/_content_gateway/push_staged_cgw.py
+++ b/pubtools/_content_gateway/push_staged_cgw.py
@@ -96,7 +96,7 @@ class PushStagedCGW(PushBase):
                 parsed_items = format_cgw_items(parsed_items)
 
                 for pitem in parsed_items:
-                    validate_data(pitem, staged=True)
+                    validate_data(pitem)
 
                 parsed_items = sort_items(parsed_items)
                 try:

--- a/pubtools/_content_gateway/utils.py
+++ b/pubtools/_content_gateway/utils.py
@@ -47,7 +47,12 @@ VERSION_SCHEMA = {
                 "invisible": {"type": "boolean"},
                 "releaseDate": {"type": "string"},
             },
-            "required": ["productName", "productCode", "versionName", "termsAndConditions"],
+            "required": [
+                "productName",
+                "productCode",
+                "versionName",
+                "termsAndConditions",
+            ],
         },
     },
     "required": ["type", "action", "metadata"],
@@ -58,56 +63,58 @@ FILE_SCHEMA = {
     "properties": {
         "type": {"type": "string"},
         "action": {"type": "string", "enum": ["create", "update", "delete"]},
-        "metadata": {"oneOf": [
-            {
-                "type": "object",
-                "properties": {
-                    "productName": {"type": "string"},
-                    "productCode": {"type": ["string", "null"]},
-                    "productVersionName": {"type": ["string", "number", "null"]},
-                    "description": {"type": ["string", "null"]},
-                    "label": {"type": ["string", "null"]},
-                    "order": {"type": "integer"},
-                    "hidden": {"type": "boolean"},
-                    "invisible": {"type": "boolean"},
-                    "type": {"type": "string"},
-                    "differentProductThankYouPage": {"type": ["number", "null"]},
-                    "shortURL": {"type": "string"},
-                    "pushItemPath": {"type": "string"},
+        "metadata": {
+            "oneOf": [
+                {
+                    "type": "object",
+                    "properties": {
+                        "productName": {"type": "string"},
+                        "productCode": {"type": ["string", "null"]},
+                        "productVersionName": {"type": ["string", "number", "null"]},
+                        "description": {"type": ["string", "null"]},
+                        "label": {"type": ["string", "null"]},
+                        "order": {"type": "integer"},
+                        "hidden": {"type": "boolean"},
+                        "invisible": {"type": "boolean"},
+                        "type": {"type": "string"},
+                        "differentProductThankYouPage": {"type": ["number", "null"]},
+                        "shortURL": {"type": "string"},
+                        "pushItemPath": {"type": "string"},
+                    },
+                    "required": [
+                        "productName",
+                        "productCode",
+                        "productVersionName",
+                        "pushItemPath",
+                    ],
                 },
-                "required": [
-                    "productName",
-                    "productCode",
-                    "productVersionName",
-                    "pushItemPath",
-                ],
-            },
-            {
-                "type": "object",
-                "properties": {
-                    "productName": {"type": "string"},
-                    "productCode": {"type": ["string", "null"]},
-                    "productVersionName": {"type": ["string", "number", "null"]},
-                    "description": {"type": ["string", "null"]},
-                    "label": {"type": ["string", "null"]},
-                    "order": {"type": "integer"},
-                    "hidden": {"type": "boolean"},
-                    "invisible": {"type": "boolean"},
-                    "type": {"type": "string"},
-                    "differentProductThankYouPage": {"type": ["number", "null"]},
-                    "downloadURL": {"type": "string"},
-                    "shortURL": {"type": "string"},
-                    "size": {"type": ["number", "null"]},
-                    "md5": {"type": ["string", "number", "null"]},
+                {
+                    "type": "object",
+                    "properties": {
+                        "productName": {"type": "string"},
+                        "productCode": {"type": ["string", "null"]},
+                        "productVersionName": {"type": ["string", "number", "null"]},
+                        "description": {"type": ["string", "null"]},
+                        "label": {"type": ["string", "null"]},
+                        "order": {"type": "integer"},
+                        "hidden": {"type": "boolean"},
+                        "invisible": {"type": "boolean"},
+                        "type": {"type": "string"},
+                        "differentProductThankYouPage": {"type": ["number", "null"]},
+                        "downloadURL": {"type": "string"},
+                        "shortURL": {"type": "string"},
+                        "size": {"type": ["number", "null"]},
+                        "md5": {"type": ["string", "number", "null"]},
+                    },
+                    "required": [
+                        "productName",
+                        "productCode",
+                        "productVersionName",
+                        "downloadURL",
+                    ],
                 },
-                "required": [
-                    "productName",
-                    "productCode",
-                    "productVersionName",
-                    "downloadURL",
-                ],
-            },
-        ]},
+            ]
+        },
     },
     "required": ["type", "action", "metadata"],
 }
@@ -136,7 +143,10 @@ def validate_data(json_data):
         validate(instance=json_data, schema=VERSION_SCHEMA)
     elif item_type == "file":
         validate(instance=json_data, schema=FILE_SCHEMA)
-    LOG.info("Data validation successful for %s: %s" % (item_type, json_data.get("metadata").get("productCode")))
+    LOG.info(
+        "Data validation successful for %s: %s"
+        % (item_type, json_data.get("metadata").get("productCode"))
+    )
     return True
 
 
@@ -194,17 +204,22 @@ def sort_items(items):
 
     for data in items:
         if data["type"] == "product":
-            product_create_update.append(data) if data["action"] in ["create", "update"] else product_delete.append(
-                data
-            )
+            product_create_update.append(data) if data["action"] in [
+                "create",
+                "update",
+            ] else product_delete.append(data)
 
         if data["type"] == "product_version":
-            version_create_update.append(data) if data["action"] in ["create", "update"] else version_delete.append(
-                data
-            )
+            version_create_update.append(data) if data["action"] in [
+                "create",
+                "update",
+            ] else version_delete.append(data)
 
         if data["type"] == "file":
-            file_create_update.append(data) if data["action"] in ["create", "update"] else file_delete.append(data)
+            file_create_update.append(data) if data["action"] in [
+                "create",
+                "update",
+            ] else file_delete.append(data)
 
     sorted_items.extend(product_create_update)
     sorted_items.extend(version_create_update)
@@ -281,8 +296,14 @@ def format_cgw_items(items):
                     for file_rec in version_rec.get("files"):
                         # file shares the same action value as product
                         file_payload = {"type": "file", "action": action}
-                        order = file_rec.get("order") if file_rec.get("order") is not None else order + 10
-                        file_rec["order"] = file_rec.get("order") if file_rec.get("order") else order
+                        order = (
+                            file_rec.get("order")
+                            if file_rec.get("order") is not None
+                            else order + 10
+                        )
+                        file_rec["order"] = (
+                            file_rec.get("order") if file_rec.get("order") else order
+                        )
                         file_payload["metadata"] = file_rec
                         file_payload["metadata"]["productName"] = product_name
                         file_payload["metadata"]["productCode"] = product_code

--- a/pubtools/_content_gateway/utils.py
+++ b/pubtools/_content_gateway/utils.py
@@ -58,69 +58,62 @@ FILE_SCHEMA = {
     "properties": {
         "type": {"type": "string"},
         "action": {"type": "string", "enum": ["create", "update", "delete"]},
-        "metadata": {
-            "type": "object",
-            "properties": {
-                "productName": {"type": "string"},
-                "productCode": {"type": ["string", "null"]},
-                "productVersionName": {"type": ["string", "number", "null"]},
-                "description": {"type": ["string", "null"]},
-                "label": {"type": ["string", "null"]},
-                "order": {"type": "integer"},
-                "hidden": {"type": "boolean"},
-                "invisible": {"type": "boolean"},
-                "type": {"type": "string"},
-                "differentProductThankYouPage": {"type": ["number", "null"]},
-                "downloadURL": {"type": "string"},
-                "shortURL": {"type": "string"},
-                "size": {"type": ["number", "null"]},
-                "md5": {"type": ["string", "number", "null"]},
+        "metadata": {"oneOf": [
+            {
+                "type": "object",
+                "properties": {
+                    "productName": {"type": "string"},
+                    "productCode": {"type": ["string", "null"]},
+                    "productVersionName": {"type": ["string", "number", "null"]},
+                    "description": {"type": ["string", "null"]},
+                    "label": {"type": ["string", "null"]},
+                    "order": {"type": "integer"},
+                    "hidden": {"type": "boolean"},
+                    "invisible": {"type": "boolean"},
+                    "type": {"type": "string"},
+                    "differentProductThankYouPage": {"type": ["number", "null"]},
+                    "shortURL": {"type": "string"},
+                    "pushItemPath": {"type": "string"},
+                },
+                "required": [
+                    "productName",
+                    "productCode",
+                    "productVersionName",
+                    "pushItemPath",
+                ],
             },
-            "required": [
-                "productName",
-                "productCode",
-                "productVersionName",
-                "downloadURL",
-            ],
-        },
-    },
-    "required": ["type", "action", "metadata"],
-}
-
-FILE_STAGED_SCHEMA = {
-    "type": "object",
-    "properties": {
-        "type": {"type": "string"},
-        "action": {"type": "string", "enum": ["create", "update", "delete"]},
-        "metadata": {
-            "type": "object",
-            "properties": {
-                "productName": {"type": "string"},
-                "productCode": {"type": ["string", "null"]},
-                "productVersionName": {"type": ["string", "number", "null"]},
-                "description": {"type": ["string", "null"]},
-                "label": {"type": ["string", "null"]},
-                "order": {"type": "integer"},
-                "hidden": {"type": "boolean"},
-                "invisible": {"type": "boolean"},
-                "type": {"type": "string"},
-                "differentProductThankYouPage": {"type": ["number", "null"]},
-                "shortURL": {"type": "string"},
-                "pushItemPath": {"type": "string"},
+            {
+                "type": "object",
+                "properties": {
+                    "productName": {"type": "string"},
+                    "productCode": {"type": ["string", "null"]},
+                    "productVersionName": {"type": ["string", "number", "null"]},
+                    "description": {"type": ["string", "null"]},
+                    "label": {"type": ["string", "null"]},
+                    "order": {"type": "integer"},
+                    "hidden": {"type": "boolean"},
+                    "invisible": {"type": "boolean"},
+                    "type": {"type": "string"},
+                    "differentProductThankYouPage": {"type": ["number", "null"]},
+                    "downloadURL": {"type": "string"},
+                    "shortURL": {"type": "string"},
+                    "size": {"type": ["number", "null"]},
+                    "md5": {"type": ["string", "number", "null"]},
+                },
+                "required": [
+                    "productName",
+                    "productCode",
+                    "productVersionName",
+                    "downloadURL",
+                ],
             },
-            "required": [
-                "productName",
-                "productCode",
-                "productVersionName",
-                "pushItemPath",
-            ],
-        },
+        ]},
     },
     "required": ["type", "action", "metadata"],
 }
 
 
-def validate_data(json_data, staged=False):
+def validate_data(json_data):
     """
     Validate that json_data contains all the necessary data
     with defined with json schemas
@@ -128,9 +121,6 @@ def validate_data(json_data, staged=False):
     Args:
         json_data (dict)
             JSON dictionary with content gateway data
-        staged (bool)
-            optional. Indicates if resulting json_data needs to
-            validate against FILE_STAGED_SCHEMA
 
     Raises:
         ValidationError
@@ -145,7 +135,7 @@ def validate_data(json_data, staged=False):
     elif item_type == "product_version":
         validate(instance=json_data, schema=VERSION_SCHEMA)
     elif item_type == "file":
-        validate(instance=json_data, schema=FILE_STAGED_SCHEMA if staged else FILE_SCHEMA)
+        validate(instance=json_data, schema=FILE_SCHEMA)
     LOG.info("Data validation successful for %s: %s" % (item_type, json_data.get("metadata").get("productCode")))
     return True
 

--- a/pubtools/_content_gateway/utils.py
+++ b/pubtools/_content_gateway/utils.py
@@ -143,10 +143,7 @@ def validate_data(json_data):
         validate(instance=json_data, schema=VERSION_SCHEMA)
     elif item_type == "file":
         validate(instance=json_data, schema=FILE_SCHEMA)
-    LOG.info(
-        "Data validation successful for %s: %s"
-        % (item_type, json_data.get("metadata").get("productCode"))
-    )
+    LOG.info("Data validation successful for %s: %s" % (item_type, json_data.get("metadata").get("productCode")))
     return True
 
 
@@ -204,22 +201,37 @@ def sort_items(items):
 
     for data in items:
         if data["type"] == "product":
-            product_create_update.append(data) if data["action"] in [
-                "create",
-                "update",
-            ] else product_delete.append(data)
+            (
+                product_create_update.append(data)
+                if data["action"]
+                in [
+                    "create",
+                    "update",
+                ]
+                else product_delete.append(data)
+            )
 
         if data["type"] == "product_version":
-            version_create_update.append(data) if data["action"] in [
-                "create",
-                "update",
-            ] else version_delete.append(data)
+            (
+                version_create_update.append(data)
+                if data["action"]
+                in [
+                    "create",
+                    "update",
+                ]
+                else version_delete.append(data)
+            )
 
         if data["type"] == "file":
-            file_create_update.append(data) if data["action"] in [
-                "create",
-                "update",
-            ] else file_delete.append(data)
+            (
+                file_create_update.append(data)
+                if data["action"]
+                in [
+                    "create",
+                    "update",
+                ]
+                else file_delete.append(data)
+            )
 
     sorted_items.extend(product_create_update)
     sorted_items.extend(version_create_update)
@@ -296,14 +308,8 @@ def format_cgw_items(items):
                     for file_rec in version_rec.get("files"):
                         # file shares the same action value as product
                         file_payload = {"type": "file", "action": action}
-                        order = (
-                            file_rec.get("order")
-                            if file_rec.get("order") is not None
-                            else order + 10
-                        )
-                        file_rec["order"] = (
-                            file_rec.get("order") if file_rec.get("order") else order
-                        )
+                        order = file_rec.get("order") if file_rec.get("order") is not None else order + 10
+                        file_rec["order"] = file_rec.get("order") if file_rec.get("order") else order
                         file_payload["metadata"] = file_rec
                         file_payload["metadata"]["productName"] = product_name
                         file_payload["metadata"]["productCode"] = product_code


### PR DESCRIPTION
Allows `pub push-staged` to maintain CGW entries also for content that already exists on CDN, using DownloadURL